### PR TITLE
Support UUID keys in maps

### DIFF
--- a/src/causal/collections/shared.cljc
+++ b/src/causal/collections/shared.cljc
@@ -40,7 +40,8 @@
 (spec/def ::id (spec/tuple ::lamport-ts ::site-id ::tx-index))
 (spec/def ::tx-id (spec/tuple ::lamport-ts ::site-id)) ; The first 2 values of an ::id make up a uniquely identifiable ::tx-id
 (spec/def ::key (spec/or :k keyword?
-                         :s string?)) ; TODO: EDN supports more key values, but for now these are all that are guaranteed to work in causal-maps
+                         :s string?
+                         :u uuid?)) ; TODO: EDN supports more key values, but for now these are all that are guaranteed to work in causal-maps
 (spec/def ::cause (spec/or :id ::id
                            :key ::key))
 (spec/def ::value (spec/or :special-k special-keywords


### PR DESCRIPTION
I have no idea what the ramifications of this might be to the convergence algorithm, but the data structure seems to initialize and perform properly for me, and the tests all pass.  I find myself using lots of UUID-keyed maps, so this is really helpful for my use-case.