### PR TITLE
Enables end user to set UUID of CausalBase

### DIFF
--- a/src/causal/base/core.cljc
+++ b/src/causal/base/core.cljc
@@ -440,6 +440,7 @@
   (undo [this] (CausalBase. (undo- (.-cb this))))
   (redo [this] (CausalBase. (redo- (.-cb this))))
   (set-site-id [this site-id] (CausalBase. (assoc (.-cb this) ::s/site-id site-id)))
+  (set-uuid [this uuid] (CausalBase. (assoc (.-cb this) ::s/uuid uuid)))
 
   proto/CausalMeta
   (get-uuid [this] (::s/uuid (.-cb this)))

--- a/src/causal/core.cljc
+++ b/src/causal/core.cljc
@@ -26,6 +26,7 @@
 (redef uuid->ref c.base/uuid->ref)
 (redef get-collection proto/get-collection)
 (redef set-site-id proto/set-site-id)
+(redef set-uuid proto/set-uuid)
 
 ;;;;;;;;;;;; Other Stuff ;;;;;;;;;;;;
 

--- a/src/causal/protocols.cljc
+++ b/src/causal/protocols.cljc
@@ -45,4 +45,6 @@
   (redo [causal-base]
     "Redo a transaction by the local site-id.")
   (set-site-id [causal-base site-id]
-    "Sets the local site-id."))
+    "Sets the local site-id.")
+  (set-uuid [causal-base uuid]
+    "Sets the root UUID."))

--- a/test/causal/base/core_test.cljc
+++ b/test/causal/base/core_test.cljc
@@ -219,6 +219,13 @@
       (= "my-site-id")
       (is)))
 
+(deftest test-set-uuid
+  (-> (c/base)
+      (c/set-uuid "my-uuid")
+      (c/get-uuid)
+      (= "my-uuid")
+      (is)))
+
 (comment
   (do
     (test-cb->edn)


### PR DESCRIPTION
I couldn't find anything that this change might break, so here's a PR addressing #12.  The test is quasi-meaningless, but it's all I could come up with given my currently shallow understanding of the codebase.